### PR TITLE
Implement coding-in-parallel agent scaffold

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+install:
+python -m venv .venv && . .venv/bin/activate && pip install -e .
+
+run:
+swe-fix-agent --repo $$REPO --task $$TASK --out /tmp/patch.diff --test-cmd "pytest -q"
+
+logs:
+@ls -ltr .agent_runs | tail -n 5
+
+lint:
+python -m py_compile $(shell git ls-files '*.py')

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # coding-in-parallel
+
+`coding-in-parallel` is a reference implementation of the SWE Fix Agent described in the
+project specification. It focuses on deterministic orchestration for SWE-bench Verified tasks,
+including AST-guided localisation, planning, diff synthesis, and transactional execution with
+git-based rollbacks.
+
+## Features
+
+- Python-only pipeline with prompt-driven investigation and planning phases.
+- Transactional execution (TNR) with static checks and targeted test gates.
+- Structured run logging and reproducible configuration via `config.yaml`.
+
+## Development
+
+Create a virtual environment and install the project in editable mode:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[test]
+```
+
+Run the test suite with `pytest`:
+
+```bash
+pytest
+```
+
+The CLI entrypoint `coding-in-parallel` can be invoked manually once configured with a
+SWE-bench instance JSON and repository checkout.
+

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,21 @@
+model:
+  provider: "openai"
+  name: "gpt-5-reasoning"
+search:
+  max_steps: 4
+  diffs_per_step: 6
+  finalists: 2
+  retries_per_step: 1
+limits:
+  max_loc_changes: 12
+  max_files_per_diff: 2
+  slice_padding_lines: 80
+tnr:
+  actions_per_txn: 3
+  require_mu_nonworsening: true
+gates:
+  static: true
+  targeted_tests: true
+  smoke: false
+logging:
+  dir: ".agent_runs"

--- a/prompts/ast_recall.txt
+++ b/prompts/ast_recall.txt
@@ -1,0 +1,2 @@
+You are the AST investigator. Given failing tests {failing_tests} for task {instance_id},
+return a JSON array of candidate spans with keys id, hypothesis, spans, and evidence.

--- a/prompts/probe.txt
+++ b/prompts/probe.txt
@@ -1,0 +1,2 @@
+For task {instance_id} candidate {candidate_id} (hypothesis: {hypothesis}),
+return a probe JSON object with notes and assumptions summarising the investigation.

--- a/prompts/propose_diff.txt
+++ b/prompts/propose_diff.txt
@@ -1,0 +1,5 @@
+You must return a JSON list (length <= {k}) of objects with step_id, unified_diff, rationale.
+Step intent: {step}
+Target files: {spans}
+Context:
+{context}

--- a/prompts/synthesize.txt
+++ b/prompts/synthesize.txt
@@ -1,0 +1,2 @@
+SYNTHESIZE the following candidate hypotheses into JSON with keys summary, invariants, dependencies:
+{candidates}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "coding-in-parallel"
+version = "0.1.0"
+description = "Transactional SWE-bench fixer agent"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{name = "OpenAI", email = "support@openai.com"}]
+dependencies = []
+
+[project.optional-dependencies]
+test = ["pytest>=7"]
+
+[project.scripts]
+coding-in-parallel = "coding_in_parallel.main:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/src/coding_in_parallel/__init__.py
+++ b/src/coding_in_parallel/__init__.py
@@ -1,0 +1,20 @@
+"""coding-in-parallel package."""
+
+from . import ast_index, controller, gates, investigator, llm, logging, main, planner, proposer, tnr, types, validate, vcs  # noqa: F401
+
+__all__ = [
+    "ast_index",
+    "controller",
+    "gates",
+    "investigator",
+    "llm",
+    "logging",
+    "main",
+    "planner",
+    "proposer",
+    "tnr",
+    "types",
+    "validate",
+    "vcs",
+]
+

--- a/src/coding_in_parallel/ast_index.py
+++ b/src/coding_in_parallel/ast_index.py
@@ -1,0 +1,110 @@
+"""AST-based indexing utilities for localisation."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping
+
+from . import types
+
+
+@dataclass
+class AstIndex:
+    """In-memory representation of symbols and call-sites."""
+
+    root: Path
+    _symbols: Mapping[str, List[types.AstSpan]]
+    _calls: Mapping[str, List[types.AstSpan]]
+    _file_cache: Mapping[str, List[str]]
+
+    def lookup_symbol(self, symbol: str) -> List[types.AstSpan]:
+        return list(self._symbols.get(symbol, []))
+
+    def lookup_calls(self, name: str) -> List[types.AstSpan]:
+        return list(self._calls.get(name, []))
+
+    def slice(self, file: str, start_line: int, end_line: int, padding: int = 0) -> str:
+        lines = self._file_cache[file]
+        start = max(start_line - 1 - padding, 0)
+        end = min(end_line + padding, len(lines))
+        return "".join(lines[start:end])
+
+
+class _CallVisitor(ast.NodeVisitor):
+    def __init__(self, file: str, calls: Dict[str, List[types.AstSpan]]):
+        self.file = file
+        self.calls = calls
+
+    def visit_Call(self, node: ast.Call) -> None:  # pragma: no cover - simple delegation
+        name = self._call_name(node.func)
+        if name:
+            span = types.AstSpan(
+                file=self.file,
+                start_line=node.lineno,
+                end_line=getattr(node, "end_lineno", node.lineno),
+                node_type="Call",
+                symbol=name,
+            )
+            self.calls.setdefault(name, []).append(span)
+        self.generic_visit(node)
+
+    @staticmethod
+    def _call_name(expr: ast.AST) -> str | None:
+        if isinstance(expr, ast.Name):
+            return expr.id
+        if isinstance(expr, ast.Attribute):
+            return expr.attr
+        return None
+
+
+def _walk_python_files(repo_path: Path) -> Iterable[Path]:
+    for path in repo_path.rglob("*.py"):
+        if path.is_file():
+            yield path
+
+
+def build_index(repo_path: Path | str) -> AstIndex:
+    """Build an :class:`AstIndex` for the given repository."""
+
+    root = Path(repo_path)
+    symbol_map: Dict[str, List[types.AstSpan]] = {}
+    call_map: Dict[str, List[types.AstSpan]] = {}
+    file_cache: Dict[str, List[str]] = {}
+
+    for file_path in _walk_python_files(root):
+        rel = file_path.relative_to(root).as_posix()
+        text = file_path.read_text()
+        file_cache[rel] = text.splitlines(keepends=True)
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                span = types.AstSpan(
+                    file=rel,
+                    start_line=node.lineno,
+                    end_line=getattr(node, "end_lineno", node.lineno),
+                    node_type="FunctionDef",
+                    symbol=node.name,
+                )
+                symbol_map.setdefault(node.name, []).append(span)
+            elif isinstance(node, ast.ClassDef):
+                span = types.AstSpan(
+                    file=rel,
+                    start_line=node.lineno,
+                    end_line=getattr(node, "end_lineno", node.lineno),
+                    node_type="ClassDef",
+                    symbol=node.name,
+                )
+                symbol_map.setdefault(node.name, []).append(span)
+
+        visitor = _CallVisitor(rel, call_map)
+        visitor.visit(tree)
+
+    return AstIndex(root=root, _symbols=symbol_map, _calls=call_map, _file_cache=file_cache)
+
+

--- a/src/coding_in_parallel/controller.py
+++ b/src/coding_in_parallel/controller.py
@@ -1,0 +1,54 @@
+"""Controller orchestrating the agent loop."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+
+from . import investigator, planner, proposer, tnr, types, vcs
+
+
+@dataclass
+class ControllerResult:
+    final_patch: str
+    transactions: List[tnr.TransactionResult]
+    understanding: types.Understanding
+    plan: List[types.PlanStep] = field(default_factory=list)
+
+
+def _load_context(repo_path: str, step: types.PlanStep) -> dict[str, str]:
+    root = Path(repo_path)
+    context: dict[str, str] = {}
+    for span in step.target_spans:
+        file_path = root / span.file
+        if file_path.exists():
+            context[span.file] = file_path.read_text()
+    return context
+
+
+def run_controller(ctx: types.TaskContext, *, max_steps: int = 4, diffs_per_step: int = 3) -> ControllerResult:
+    """Run the investigation → planning → execution loop."""
+
+    candidates = investigator.recall_candidates(ctx)
+    candidates = investigator.probe(ctx, candidates)
+    understanding = planner.synthesize(candidates)
+    plan = planner.plan(understanding)[:max_steps]
+
+    transactions: List[tnr.TransactionResult] = []
+    for step in plan:
+        ctx_files = _load_context(ctx.repo_path, step)
+        proposals = proposer.propose(step, ctx_files, diffs_per_step)
+        result = tnr.txn_patch(ctx, step, proposals, max_actions=diffs_per_step)
+        transactions.append(result)
+        if result.committed:
+            break
+
+    patch = vcs.final_patch(ctx.repo_path)
+    if not patch and transactions:
+        last = transactions[-1]
+        if last.applied_diff is not None:
+            patch = last.applied_diff.unified_diff
+    return ControllerResult(final_patch=patch, transactions=transactions, understanding=understanding, plan=plan)
+
+

--- a/src/coding_in_parallel/gates.py
+++ b/src/coding_in_parallel/gates.py
@@ -1,0 +1,41 @@
+"""Gate execution for transactions."""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Tuple
+
+
+def run_static_checks(repo_path: str) -> Tuple[bool, str]:
+    """Run lightweight static checks using ``py_compile``."""
+
+    root = Path(repo_path)
+    py_files = [str(path) for path in root.rglob("*.py") if path.is_file()]
+    if not py_files:
+        return True, "no python files"
+    cmd = [sys.executable, "-m", "py_compile", *py_files]
+    proc = subprocess.run(cmd, cwd=repo_path, capture_output=True, text=True)
+    success = proc.returncode == 0
+    output = proc.stdout + proc.stderr
+    return success, output
+
+
+def run_targeted_tests(test_cmd: str, repo_path: str) -> Tuple[bool, str]:
+    """Run the provided targeted test command."""
+
+    if not test_cmd:
+        return True, "no tests configured"
+    proc = subprocess.run(
+        shlex.split(test_cmd),
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    success = proc.returncode == 0
+    output = proc.stdout + proc.stderr
+    return success, output
+
+

--- a/src/coding_in_parallel/investigator.py
+++ b/src/coding_in_parallel/investigator.py
@@ -1,0 +1,73 @@
+"""Read-only investigative helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List
+
+from . import ast_index, llm, types
+
+_PROMPT_DIR = Path(__file__).resolve().parents[2] / "prompts"
+
+
+def _load_prompt(name: str) -> str:
+    path = _PROMPT_DIR / name
+    if not path.exists():
+        raise FileNotFoundError(f"Prompt {name} not found at {path}")
+    return path.read_text().strip()
+
+
+def recall_candidates(ctx: types.TaskContext) -> List[types.Candidate]:
+    """Use the recall prompt to fetch candidate spans."""
+
+    prompt = _load_prompt("ast_recall.txt")
+    _ = ast_index.build_index(ctx.repo_path)
+    payload = {
+        "instance_id": ctx.instance_id,
+        "failing_tests": ctx.failing_tests,
+    }
+    response = llm.complete(prompt.format(**payload))
+    raw_candidates = json.loads(response or "[]")
+    candidates: List[types.Candidate] = []
+    for raw in raw_candidates:
+        spans = [
+            types.AstSpan(
+                file=span["file"],
+                start_line=span["start_line"],
+                end_line=span["end_line"],
+                node_type=span["node_type"],
+                symbol=span.get("symbol"),
+                score=span.get("score"),
+            )
+            for span in raw.get("spans", [])
+        ]
+        candidates.append(
+            types.Candidate(
+                id=raw.get("id", f"cand-{len(candidates)+1}"),
+                hypothesis=raw.get("hypothesis", ""),
+                spans=spans,
+                evidence=raw.get("evidence", {}),
+            )
+        )
+    return candidates
+
+
+def probe(ctx: types.TaskContext, candidates: Iterable[types.Candidate]) -> List[types.Candidate]:
+    """Run probe prompt per candidate and attach the response."""
+
+    prompt_template = _load_prompt("probe.txt")
+    enriched: List[types.Candidate] = []
+    for candidate in candidates:
+        payload = {
+            "instance_id": ctx.instance_id,
+            "candidate_id": candidate.id,
+            "hypothesis": candidate.hypothesis,
+        }
+        response = llm.complete(prompt_template.format(**payload))
+        notes = json.loads(response or "{}")
+        candidate.evidence.setdefault("probe", notes)
+        enriched.append(candidate)
+    return enriched
+
+

--- a/src/coding_in_parallel/llm.py
+++ b/src/coding_in_parallel/llm.py
@@ -1,0 +1,35 @@
+"""LLM provider shim used throughout the agent."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class SupportsComplete(Protocol):
+    def complete(self, prompt: str, **kwargs: Any) -> str:  # pragma: no cover - protocol
+        ...
+
+
+class _DefaultClient:
+    def complete(self, prompt: str, **_: Any) -> str:
+        raise RuntimeError(
+            "No LLM client configured. Call coding_in_parallel.llm.set_client() before use."
+        )
+
+
+_client: SupportsComplete = _DefaultClient()
+
+
+def set_client(client: SupportsComplete) -> None:
+    """Register a global client used by :func:`complete`."""
+
+    global _client
+    _client = client
+
+
+def complete(prompt: str, **kwargs: Any) -> str:
+    """Delegate to the configured LLM client."""
+
+    return _client.complete(prompt, **kwargs)
+
+

--- a/src/coding_in_parallel/logging.py
+++ b/src/coding_in_parallel/logging.py
@@ -1,0 +1,35 @@
+"""Structured logging utilities for agent runs."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+
+class RunLogger:
+    """Persist structured artefacts for a single agent run."""
+
+    def __init__(self, base_dir: str | Path = ".agent_runs", run_id: str | None = None):
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        if run_id is None:
+            run_id = time.strftime("%Y%m%d-%H%M%S")
+        self.run_dir = self.base_dir / run_id
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+
+    def path_for(self, name: str, suffix: str) -> Path:
+        return self.run_dir / f"{name}.{suffix}"
+
+    def log_json(self, name: str, data: Any) -> Path:
+        path = self.path_for(name, "json")
+        path.write_text(json.dumps(data, indent=2, sort_keys=True))
+        return path
+
+    def log_text(self, name: str, text: str) -> Path:
+        path = self.path_for(name, "txt")
+        path.write_text(text)
+        return path
+
+

--- a/src/coding_in_parallel/main.py
+++ b/src/coding_in_parallel/main.py
@@ -1,0 +1,40 @@
+"""CLI entrypoint for coding-in-parallel."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+from . import controller, types
+
+
+def _parse_args(args: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="coding-in-parallel")
+    parser.add_argument("--repo", required=True, help="Path to the repository")
+    parser.add_argument("--task", required=True, help="Path to SWE-bench task JSON")
+    parser.add_argument("--out", required=True, help="Where to write the final patch")
+    parser.add_argument("--test-cmd", required=True, help="Command used for targeted tests")
+    return parser.parse_args(list(args) if args is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    ns = _parse_args(argv)
+    task_data = json.loads(Path(ns.task).read_text())
+    ctx = types.TaskContext(
+        repo_path=ns.repo,
+        failing_tests=list(task_data.get("failing_tests", [])),
+        test_cmd=ns.test_cmd or task_data.get("test_cmd", ""),
+        targeted_expr=task_data.get("targeted_expr"),
+        instance_id=task_data.get("instance_id", "unknown"),
+        metadata=task_data.get("metadata", {}),
+    )
+    result = controller.run_controller(ctx)
+    Path(ns.out).write_text(result.final_patch)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+
+

--- a/src/coding_in_parallel/planner.py
+++ b/src/coding_in_parallel/planner.py
@@ -1,0 +1,69 @@
+"""Planner that turns understanding into plan steps."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List
+
+from . import llm, types
+
+_PROMPT_DIR = Path(__file__).resolve().parents[2] / "prompts"
+
+
+def _load_prompt(name: str) -> str:
+    path = _PROMPT_DIR / name
+    if not path.exists():
+        raise FileNotFoundError(f"Prompt {name} not found at {path}")
+    return path.read_text().strip()
+
+
+def synthesize(candidates: Iterable[types.Candidate]) -> types.Understanding:
+    """Combine candidate notes into a structured understanding."""
+
+    template = _load_prompt("synthesize.txt")
+    payload = {
+        "candidates": [candidate.hypothesis for candidate in candidates],
+    }
+    response = llm.complete(template.format(**payload))
+    data = json.loads(response or "{}")
+    return types.Understanding(
+        summary=data.get("summary", ""),
+        invariants=list(data.get("invariants", [])),
+        dependencies=list(data.get("dependencies", [])),
+    )
+
+
+def plan(understanding: types.Understanding) -> List[types.PlanStep]:
+    """Request a list of plan steps from the LLM."""
+
+    template = _load_prompt("synthesize.txt")
+    prompt = f"{template}\nPLAN: {understanding.summary}"
+    response = llm.complete(prompt)
+    items = json.loads(response or "[]")
+    steps: List[types.PlanStep] = []
+    for raw in items:
+        spans = [
+            types.AstSpan(
+                file=span["file"],
+                start_line=span["start_line"],
+                end_line=span["end_line"],
+                node_type=span["node_type"],
+                symbol=span.get("symbol"),
+                score=span.get("score"),
+            )
+            for span in raw.get("target_spans", [])
+        ]
+        steps.append(
+            types.PlanStep(
+                id=raw.get("id", f"step-{len(steps)+1}"),
+                intent=raw.get("intent", ""),
+                target_spans=spans,
+                constraints=list(raw.get("constraints", [])),
+                ideal_outcome=raw.get("ideal_outcome", ""),
+                check=raw.get("check", "tests"),
+            )
+        )
+    return steps
+
+

--- a/src/coding_in_parallel/proposer.py
+++ b/src/coding_in_parallel/proposer.py
@@ -1,0 +1,47 @@
+"""Diff proposer producing unified diff candidates."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from . import llm, types
+
+_PROMPT_DIR = Path(__file__).resolve().parents[2] / "prompts"
+
+
+def _load_prompt(name: str) -> str:
+    path = _PROMPT_DIR / name
+    if not path.exists():
+        raise FileNotFoundError(f"Prompt {name} not found at {path}")
+    return path.read_text().strip()
+
+
+def propose(step: types.PlanStep, ctx_files: Dict[str, str], k: int) -> List[types.DiffProposal]:
+    """Produce up to *k* unified diff proposals for *step*."""
+
+    prompt = _load_prompt("propose_diff.txt")
+    context_lines = []
+    for file, content in ctx_files.items():
+        context_lines.append(f"FILE: {file}\n{content}")
+    payload = {
+        "step": step.intent,
+        "spans": [span.file for span in step.target_spans],
+        "context": "\n".join(context_lines),
+        "k": k,
+    }
+    response = llm.complete(prompt.format(**payload))
+    items = json.loads(response or "[]")
+    proposals: List[types.DiffProposal] = []
+    for raw in items[:k]:
+        proposals.append(
+            types.DiffProposal(
+                step_id=raw.get("step_id", step.id),
+                unified_diff=raw["unified_diff"],
+                rationale=raw.get("rationale"),
+            )
+        )
+    return proposals
+
+

--- a/src/coding_in_parallel/tnr.py
+++ b/src/coding_in_parallel/tnr.py
@@ -1,0 +1,94 @@
+"""Transactional no-regression execution."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from typing import Iterable, List
+
+from . import gates, types, validate, vcs
+
+_MAX_LOC = 12
+_MAX_FILES = 2
+
+
+@dataclass
+class TransactionResult:
+    committed: bool
+    applied_diff: types.DiffProposal | None
+    mu_pre: int
+    mu_post: int
+    logs: List[str] = field(default_factory=list)
+
+
+def _measure_mu(repo_path: str) -> int:
+    proc = subprocess.run(
+        ["git", "diff", "--numstat"],
+        cwd=repo_path,
+        text=True,
+        capture_output=True,
+    )
+    total = 0
+    for line in proc.stdout.splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[0].isdigit() and parts[1].isdigit():
+            total += (int(parts[0]) + int(parts[1])) // 2
+    return total
+
+
+def txn_patch(
+    ctx: types.TaskContext,
+    step: types.PlanStep,
+    proposals: Iterable[types.DiffProposal],
+    *,
+    max_actions: int = 3,
+) -> TransactionResult:
+    """Attempt to apply one of the provided diff proposals as a transaction."""
+
+    repo_path = ctx.repo_path
+    head = vcs.checkpoint(repo_path)
+    mu_pre = _measure_mu(repo_path)
+    allowed_files = {span.file for span in step.target_spans}
+
+    for attempt, proposal in enumerate(proposals, start=1):
+        if attempt > max_actions:
+            break
+        try:
+            validate.ensure_within_limits(
+                proposal.unified_diff,
+                allowed_files=allowed_files,
+                max_loc=_MAX_LOC,
+                max_files=_MAX_FILES,
+                target_spans=step.target_spans,
+            )
+        except validate.ValidationError as exc:  # pragma: no cover - guard rails
+            return TransactionResult(False, None, mu_pre, mu_pre, logs=[str(exc)])
+
+        try:
+            vcs.apply_diff(proposal.unified_diff, repo_path)
+        except RuntimeError as exc:
+            vcs.revert(repo_path, head)
+            return TransactionResult(False, None, mu_pre, mu_pre, logs=[str(exc)])
+
+        ok, output = gates.run_static_checks(repo_path)
+        if not ok:
+            vcs.revert(repo_path, head)
+            return TransactionResult(False, None, mu_pre, mu_pre, logs=[output])
+
+        ok, output = gates.run_targeted_tests(ctx.test_cmd, repo_path)
+        if not ok:
+            vcs.revert(repo_path, head)
+            return TransactionResult(False, None, mu_pre, mu_pre, logs=[output])
+
+        vcs.stage_all(repo_path)
+        vcs.commit(repo_path, f"txn:{step.id}")
+        mu_post = _measure_mu(repo_path)
+        if mu_post <= mu_pre:
+            return TransactionResult(True, proposal, mu_pre, mu_post)
+        # if mu worsened, rollback and continue.
+        vcs.revert(repo_path, head)
+
+    vcs.revert(repo_path, head)
+    return TransactionResult(False, None, mu_pre, mu_pre)
+
+

--- a/src/coding_in_parallel/types.py
+++ b/src/coding_in_parallel/types.py
@@ -1,0 +1,72 @@
+"""Core datatypes for coding-in-parallel."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class AstSpan:
+    """Represents a span of code located by the AST index."""
+
+    file: str
+    start_line: int
+    end_line: int
+    node_type: str
+    symbol: Optional[str] = None
+    score: Optional[float] = None
+
+
+@dataclass
+class Candidate:
+    """Investigation candidate returned from the recall phase."""
+
+    id: str
+    hypothesis: str
+    spans: List[AstSpan]
+    evidence: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Understanding:
+    """High-level understanding synthesised from probes."""
+
+    summary: str
+    invariants: List[str]
+    dependencies: List[str]
+
+
+@dataclass
+class PlanStep:
+    """Atomic step in the execution plan."""
+
+    id: str
+    intent: str
+    target_spans: List[AstSpan]
+    constraints: List[str]
+    ideal_outcome: str
+    check: str
+
+
+@dataclass
+class DiffProposal:
+    """Unified diff proposal returned from the proposer."""
+
+    step_id: str
+    unified_diff: str
+    rationale: Optional[str] = None
+
+
+@dataclass
+class TaskContext:
+    """Execution context for a SWE-bench task."""
+
+    repo_path: str
+    failing_tests: List[str]
+    test_cmd: str
+    targeted_expr: Optional[str]
+    instance_id: str
+    metadata: Dict[str, Any]
+
+

--- a/src/coding_in_parallel/validate.py
+++ b/src/coding_in_parallel/validate.py
@@ -1,0 +1,65 @@
+"""Validation helpers for proposals and diffs."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, Set
+
+from . import types
+
+_DIFF_HEADER_RE = re.compile(r"^diff --git a/(?P<afile>[^\s]+) b/(?P<bfile>[^\s]+)", re.MULTILINE)
+
+
+class ValidationError(RuntimeError):
+    """Raised when a proposal fails validation."""
+
+
+def require_unified_diff(diff: str) -> None:
+    """Ensure the string looks like a unified diff."""
+
+    if not diff.startswith("diff --git"):
+        raise ValidationError("Diff must start with 'diff --git'.")
+    if "@@" not in diff:
+        raise ValidationError("Diff must contain a hunk header '@@'.")
+    for line in diff.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("+def") or stripped.startswith("+class"):
+            if stripped.endswith("::"):
+                raise ValidationError("Suspicious double-colon in definition header.")
+
+
+def _count_changed_loc(diff: str) -> int:
+    return sum(1 for line in diff.splitlines() if line.startswith("+") or line.startswith("-"))
+
+
+def _touched_files(diff: str) -> Set[str]:
+    matches = _DIFF_HEADER_RE.findall(diff)
+    return {b for _a, b in matches}
+
+
+def ensure_within_limits(
+    diff: str,
+    *,
+    allowed_files: Set[str],
+    max_loc: int,
+    max_files: int,
+    target_spans: Iterable[types.AstSpan],
+) -> None:
+    """Check diff obeys configured limits."""
+
+    require_unified_diff(diff)
+    files = _touched_files(diff)
+    if not files:
+        raise ValidationError("Diff must touch at least one file header.")
+    if len(files) > max_files:
+        raise ValidationError("Diff touches too many files.")
+    if not files.issubset(allowed_files):
+        raise ValidationError("Diff touches files outside of allowed set.")
+    loc = _count_changed_loc(diff)
+    if loc > max_loc:
+        raise ValidationError("Diff changes too many lines.")
+    span_files = {span.file for span in target_spans}
+    if not files.intersection(span_files):
+        raise ValidationError("Diff does not touch any target span files.")
+
+

--- a/src/coding_in_parallel/vcs.py
+++ b/src/coding_in_parallel/vcs.py
@@ -1,0 +1,155 @@
+"""VCS plumbing helpers built on Git."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any, Optional
+
+
+def _normalize_diff(diff: str) -> str:
+    lines = diff.splitlines()
+    output: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("diff --git"):
+            output.append(line)
+            parts = line.split()
+            a_path = parts[2]
+            b_path = parts[3]
+            i += 1
+            if i < len(lines) and lines[i].startswith("--- "):
+                output.append(lines[i])
+                i += 1
+            else:
+                output.append(f"--- {a_path}")
+            if i < len(lines) and lines[i].startswith("+++ "):
+                output.append(lines[i])
+                i += 1
+            else:
+                output.append(f"+++ {b_path}")
+            continue
+        output.append(line)
+        i += 1
+    text = "\n".join(output)
+    if diff.endswith("\n") and not text.endswith("\n"):
+        text += "\n"
+    return text
+
+
+def _run_git(
+    repo_path: str,
+    *args: str,
+    check: bool = True,
+    input: Optional[str] = None,
+    **kwargs: Any,
+) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=repo_path,
+        input=input,
+        text=True,
+        capture_output=True,
+        **kwargs,
+    )
+    if check and proc.returncode != 0:
+        raise RuntimeError(proc.stderr or proc.stdout)
+    return proc
+
+
+def apply_diff(diff: str, repo_path: str) -> None:
+    """Apply a unified diff to the repository."""
+
+    normalized = _normalize_diff(diff)
+    try:
+        _run_git(repo_path, "apply", "-", input=normalized)
+    except RuntimeError:
+        _manual_apply(normalized, repo_path)
+
+
+def _manual_apply(diff: str, repo_path: str) -> None:
+    lines = diff.splitlines()
+    i = 0
+    while i < len(lines):
+        if not lines[i].startswith("diff --git"):
+            i += 1
+            continue
+        parts = lines[i].split()
+        b_path = parts[3][2:]
+        i += 1
+        # Skip ---/+++ headers if present
+        while i < len(lines) and lines[i].startswith("---"):
+            i += 1
+        while i < len(lines) and lines[i].startswith("+++"):
+            i += 1
+        hunk: list[str] = []
+        while i < len(lines) and not lines[i].startswith("diff --git"):
+            hunk.append(lines[i])
+            i += 1
+        _apply_hunks(repo_path, b_path, hunk)
+
+
+def _apply_hunks(repo_path: str, file_rel: str, hunk_lines: list[str]) -> None:
+    path = Path(repo_path) / file_rel
+    original = path.read_text().splitlines(keepends=True)
+    pointer = 0
+    output: list[str] = []
+    for line in hunk_lines:
+        if line.startswith("@@"):
+            continue
+        if line.startswith(" "):
+            if pointer < len(original):
+                output.append(original[pointer])
+                pointer += 1
+        elif line.startswith("-"):
+            pointer += 1
+        elif line.startswith("+"):
+            text = line[1:]
+            if not text.endswith("\n"):
+                text += "\n"
+            output.append(text)
+    output.extend(original[pointer:])
+    path.write_text("".join(output))
+
+
+def checkpoint(repo_path: str) -> str:
+    """Return the current HEAD commit hash."""
+
+    proc = _run_git(repo_path, "rev-parse", "HEAD")
+    return proc.stdout.strip()
+
+
+def revert(repo_path: str, commit_id: str) -> None:
+    """Hard reset to the given commit."""
+
+    _run_git(repo_path, "reset", "--hard", commit_id)
+    _run_git(repo_path, "clean", "-fd")
+
+
+def stage_all(repo_path: str) -> None:
+    _run_git(repo_path, "add", "-A")
+
+
+def commit(repo_path: str, message: str) -> str:
+    """Create a commit with all staged changes."""
+
+    stage_all(repo_path)
+    proc = _run_git(repo_path, "commit", "-m", message)
+    return proc.stdout.strip()
+
+
+def final_patch(repo_path: str) -> str:
+    """Return the diff between HEAD and the working tree."""
+
+    proc = _run_git(repo_path, "diff", "HEAD")
+    return proc.stdout
+
+
+def clean(repo_path: str) -> None:
+    """Discard uncommitted changes."""
+
+    _run_git(repo_path, "reset", "--hard")
+    _run_git(repo_path, "clean", "-fd")
+
+

--- a/tests/test_agent_logging.py
+++ b/tests/test_agent_logging.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from coding_in_parallel import logging as agent_logging
+
+
+def test_run_logger_creates_files(tmp_path: Path):
+    logger = agent_logging.RunLogger(base_dir=tmp_path, run_id="demo")
+    logger.log_json("candidates", {"items": [1, 2, 3]})
+    logger.log_text("mu", "pre=0\npost=1")
+    run_dir = tmp_path / "demo"
+    assert run_dir.exists()
+    assert (run_dir / "candidates.json").read_text().strip().startswith("{")
+    assert "pre=0" in (run_dir / "mu.txt").read_text()
+

--- a/tests/test_ast_index.py
+++ b/tests/test_ast_index.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import pytest
+
+from coding_in_parallel import ast_index
+
+
+@pytest.fixture()
+def sample_repo(tmp_path: Path) -> Path:
+    package = tmp_path / "pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("from .module import greet\n")
+    (package / "module.py").write_text(
+        """def greet(name: str) -> str:\n    return f'Hello {name}'\n\n\nclass Speaker:\n    def say(self, message: str) -> str:\n        return greet(message)\n"""
+    )
+    return package
+
+
+def test_build_index_finds_definitions(sample_repo: Path):
+    index = ast_index.build_index(sample_repo)
+    spans = index.lookup_symbol("greet")
+    assert spans, "Expected greet definition span"
+    span = spans[0]
+    assert span.file.endswith("module.py")
+    assert span.node_type == "FunctionDef"
+    calls = index.lookup_calls("greet")
+    assert any(call.file.endswith("module.py") for call in calls)
+
+
+def test_slice_reads_requested_lines(sample_repo: Path):
+    index = ast_index.build_index(sample_repo)
+    slice_text = index.slice("module.py", 1, 2)
+    assert "def greet" in slice_text
+    assert "return f'Hello" in slice_text
+

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from coding_in_parallel import controller, investigator, planner, proposer, tnr, types
+
+
+def _init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=path, check=True)
+    (path / "mod.py").write_text("def add(x, y):\n    return x - y\n")
+    subprocess.run(["git", "add", "mod.py"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=path, check=True, capture_output=True)
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    _init_git_repo(tmp_path)
+    return tmp_path
+
+
+def test_run_controller_applies_committed_diff(monkeypatch: pytest.MonkeyPatch, repo: Path):
+    ctx = types.TaskContext(
+        repo_path=str(repo),
+        failing_tests=["tests/test_mod.py::test_add"],
+        test_cmd="pytest -k add",
+        targeted_expr=None,
+        instance_id="example-1",
+        metadata={},
+    )
+    candidate = types.Candidate(
+        id="cand-1",
+        hypothesis="add subtracts",
+        spans=[types.AstSpan(file="mod.py", start_line=1, end_line=2, node_type="FunctionDef")],
+        evidence={},
+    )
+    step = types.PlanStep(
+        id="step-1",
+        intent="Fix add",
+        target_spans=candidate.spans,
+        constraints=[],
+        ideal_outcome="add sums",
+        check="tests",
+    )
+    diff = types.DiffProposal(
+        step_id="step-1",
+        unified_diff="""diff --git a/mod.py b/mod.py\n@@\n-def add(x, y):\n-    return x - y\n+def add(x, y):\n+    return x + y\n""",
+        rationale="fix",
+    )
+
+    monkeypatch.setattr(investigator, "recall_candidates", lambda ctx: [candidate])
+    monkeypatch.setattr(investigator, "probe", lambda ctx, cands: cands)
+    monkeypatch.setattr(planner, "synthesize", lambda cands: types.Understanding("Fix add", [], []))
+    monkeypatch.setattr(planner, "plan", lambda understanding: [step])
+    monkeypatch.setattr(proposer, "propose", lambda step, ctx_files, k: [diff])
+
+    def fake_txn(context, plan_step, proposals, *, max_actions=3):
+        return tnr.TransactionResult(
+            committed=True,
+            applied_diff=diff,
+            mu_pre=0,
+            mu_post=1,
+        )
+
+    monkeypatch.setattr(tnr, "txn_patch", fake_txn)
+
+    result = controller.run_controller(ctx)
+    assert result.final_patch == diff.unified_diff
+    assert result.transactions[0].committed
+
+

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+from coding_in_parallel import gates
+
+
+def test_run_static_checks_detects_syntax_error(tmp_path: Path):
+    package = tmp_path / "pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("def broken(:\n    pass\n")
+    ok, output = gates.run_static_checks(str(tmp_path))
+    assert not ok
+    assert "SyntaxError" in output
+
+
+def test_run_targeted_tests_executes_command(tmp_path: Path):
+    script = tmp_path / "script.py"
+    script.write_text("import sys; sys.exit(0)")
+    ok, output = gates.run_targeted_tests(f"{sys.executable} {script}", str(tmp_path))
+    assert ok
+

--- a/tests/test_investigator.py
+++ b/tests/test_investigator.py
@@ -1,0 +1,86 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from coding_in_parallel import investigator, llm, types
+
+
+@pytest.fixture()
+def repo_with_bug(tmp_path: Path) -> Path:
+    file_path = tmp_path / "mod.py"
+    file_path.write_text(
+        """def add(x, y):\n    return x-y\n"""
+    )
+    return tmp_path
+
+
+def _make_ctx(repo_path: Path) -> types.TaskContext:
+    return types.TaskContext(
+        repo_path=str(repo_path),
+        failing_tests=["tests/test_mod.py::test_add"],
+        test_cmd="pytest -k add",
+        targeted_expr=None,
+        instance_id="example-1",
+        metadata={},
+    )
+
+
+def test_recall_candidates_parses_llm_output(monkeypatch: pytest.MonkeyPatch, repo_with_bug: Path):
+    ctx = _make_ctx(repo_with_bug)
+    response = json.dumps(
+        [
+            {
+                "id": "cand-1",
+                "hypothesis": "The function subtracts instead of adds.",
+                "spans": [
+                    {
+                        "file": "mod.py",
+                        "start_line": 1,
+                        "end_line": 2,
+                        "node_type": "FunctionDef",
+                        "symbol": "add",
+                    }
+                ],
+                "evidence": {"score": 0.8},
+            }
+        ]
+    )
+
+    def fake_complete(prompt: str, **_: object) -> str:
+        assert "ast" in prompt.lower()
+        return response
+
+    monkeypatch.setattr(llm, "complete", fake_complete)
+    candidates = investigator.recall_candidates(ctx)
+    assert candidates and candidates[0].spans[0].file.endswith("mod.py")
+
+
+def test_probe_appends_notes(monkeypatch: pytest.MonkeyPatch, repo_with_bug: Path):
+    ctx = _make_ctx(repo_with_bug)
+    candidate = types.Candidate(
+        id="cand-1",
+        hypothesis="Bug in add",
+        spans=[
+            types.AstSpan(
+                file="mod.py", start_line=1, end_line=2, node_type="FunctionDef", symbol="add"
+            )
+        ],
+        evidence={},
+    )
+    probe_response = json.dumps(
+        {
+            "notes": "Function subtracts instead of adding.",
+            "assumptions": ["inputs are numbers"],
+        }
+    )
+
+    def fake_complete(prompt: str, **_: object) -> str:
+        assert "probe" in prompt.lower()
+        return probe_response
+
+    monkeypatch.setattr(llm, "complete", fake_complete)
+    enriched = investigator.probe(ctx, [candidate])
+    assert "probe" in enriched[0].evidence
+    assert "Function subtracts" in enriched[0].evidence["probe"]["notes"]
+

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,18 @@
+from coding_in_parallel import llm
+
+
+class DummyClient:
+    def __init__(self):
+        self.seen = []
+
+    def complete(self, prompt: str, **_: object) -> str:
+        self.seen.append(prompt)
+        return "{}"
+
+
+def test_set_client_overrides_default():
+    dummy = DummyClient()
+    llm.set_client(dummy)
+    llm.complete("hello")
+    assert dummy.seen == ["hello"]
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,57 @@
+import json
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from coding_in_parallel import controller, main, types
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=path, check=True)
+    (path / "mod.py").write_text("def add(x, y):\n    return x - y\n")
+    subprocess.run(["git", "add", "mod.py"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=path, check=True, capture_output=True)
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    _init_repo(tmp_path)
+    return tmp_path
+
+
+def test_main_cli_writes_patch_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, repo: Path):
+    instance = {
+        "instance_id": "example-1",
+        "test_cmd": "pytest -k add",
+        "failing_tests": ["tests/test_mod.py::test_add"],
+    }
+    instance_path = tmp_path / "instance.json"
+    instance_path.write_text(json.dumps(instance))
+    output_path = tmp_path / "patch.diff"
+
+    def fake_run_controller(ctx: types.TaskContext):
+        return controller.ControllerResult(
+            final_patch="diff --git a/mod.py b/mod.py\n",
+            transactions=[],
+            understanding=types.Understanding("", [], []),
+            plan=[],
+        )
+
+    monkeypatch.setattr(controller, "run_controller", fake_run_controller)
+
+    main.main([
+        "--repo",
+        str(repo),
+        "--task",
+        str(instance_path),
+        "--out",
+        str(output_path),
+        "--test-cmd",
+        "pytest -k add",
+    ])
+
+    assert output_path.read_text().startswith("diff --git")
+

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,60 @@
+import json
+
+import pytest
+
+from coding_in_parallel import planner, llm, types
+
+
+def test_synthesize_returns_understanding(monkeypatch: pytest.MonkeyPatch):
+    response = json.dumps(
+        {
+            "summary": "The add function subtracts.",
+            "invariants": ["inputs remain ints"],
+            "dependencies": ["mod.add"],
+        }
+    )
+
+    def fake_complete(prompt: str, **_: object) -> str:
+        assert "synthesize" in prompt.lower()
+        return response
+
+    monkeypatch.setattr(llm, "complete", fake_complete)
+    understanding = planner.synthesize([])
+    assert understanding.summary.startswith("The add function")
+
+
+def test_plan_produces_plan_steps(monkeypatch: pytest.MonkeyPatch):
+    response = json.dumps(
+        [
+            {
+                "id": "step-1",
+                "intent": "Correct the arithmetic.",
+                "target_spans": [
+                    {
+                        "file": "mod.py",
+                        "start_line": 1,
+                        "end_line": 2,
+                        "node_type": "FunctionDef",
+                    }
+                ],
+                "constraints": ["keep function signature"],
+                "ideal_outcome": "add returns x + y",
+                "check": "tests",
+            }
+        ]
+    )
+
+    def fake_complete(prompt: str, **_: object) -> str:
+        assert "plan" in prompt.lower()
+        return response
+
+    understanding = types.Understanding(
+        summary="Fix add",
+        invariants=[],
+        dependencies=[],
+    )
+    monkeypatch.setattr(llm, "complete", fake_complete)
+    steps = planner.plan(understanding)
+    assert steps[0].intent.startswith("Correct")
+    assert steps[0].target_spans[0].file == "mod.py"
+

--- a/tests/test_proposer.py
+++ b/tests/test_proposer.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from coding_in_parallel import proposer, llm, types
+
+
+def test_propose_returns_diff_list(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    (tmp_path / "mod.py").write_text("def add(x, y):\n    return x - y\n")
+    response = json.dumps(
+        [
+            {
+                "step_id": "step-1",
+                "unified_diff": "diff --git a/mod.py b/mod.py\n@@\n-def add(x, y):\n-    return x - y\n+def add(x, y):\n+    return x + y\n",
+                "rationale": "Swap subtraction for addition",
+            }
+        ]
+    )
+
+    def fake_complete(prompt: str, **_: object) -> str:
+        assert "diff" in prompt.lower()
+        return response
+
+    monkeypatch.setattr(llm, "complete", fake_complete)
+    step = types.PlanStep(
+        id="step-1",
+        intent="Fix add",
+        target_spans=[
+            types.AstSpan(
+                file="mod.py", start_line=1, end_line=2, node_type="FunctionDef", symbol="add"
+            )
+        ],
+        constraints=[],
+        ideal_outcome="add returns sum",
+        check="tests",
+    )
+    proposals = proposer.propose(step, {"mod.py": "def add(x, y):\n    return x - y\n"}, 1)
+    assert proposals and proposals[0].rationale.startswith("Swap")
+

--- a/tests/test_tnr.py
+++ b/tests/test_tnr.py
@@ -1,0 +1,86 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from coding_in_parallel import gates, tnr, types, validate, vcs
+
+
+def _init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=path, check=True)
+    (path / "mod.py").write_text("def add(x, y):\n    return x - y\n")
+    subprocess.run(["git", "add", "mod.py"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=path, check=True, capture_output=True)
+
+
+@pytest.fixture()
+def git_repo(tmp_path: Path) -> Path:
+    _init_git_repo(tmp_path)
+    return tmp_path
+
+
+def _make_context(repo_path: Path) -> types.TaskContext:
+    return types.TaskContext(
+        repo_path=str(repo_path),
+        failing_tests=["tests/test_mod.py::test_add"],
+        test_cmd="pytest -k add",
+        targeted_expr=None,
+        instance_id="example-1",
+        metadata={},
+    )
+
+
+def test_txn_patch_commits_when_checks_pass(monkeypatch: pytest.MonkeyPatch, git_repo: Path):
+    ctx = _make_context(git_repo)
+    step = types.PlanStep(
+        id="step-1",
+        intent="Fix add",
+        target_spans=[
+            types.AstSpan(file="mod.py", start_line=1, end_line=2, node_type="FunctionDef"),
+        ],
+        constraints=[],
+        ideal_outcome="add sums",
+        check="tests",
+    )
+    diff = """diff --git a/mod.py b/mod.py\n@@\n-def add(x, y):\n-    return x - y\n+def add(x, y):\n+    return x + y\n"""
+
+    monkeypatch.setattr(gates, "run_static_checks", lambda repo: (True, "ok"))
+    monkeypatch.setattr(gates, "run_targeted_tests", lambda cmd, repo: (True, "tests pass"))
+
+    result = tnr.txn_patch(ctx, step, [types.DiffProposal(step_id=step.id, unified_diff=diff, rationale="fix")])
+    assert result.committed
+    assert result.mu_post <= result.mu_pre + 2
+    assert "return x + y" in (git_repo / "mod.py").read_text()
+
+
+def test_txn_patch_rolls_back_on_failure(monkeypatch: pytest.MonkeyPatch, git_repo: Path):
+    ctx = _make_context(git_repo)
+    step = types.PlanStep(
+        id="step-1",
+        intent="Fix add",
+        target_spans=[
+            types.AstSpan(file="mod.py", start_line=1, end_line=2, node_type="FunctionDef"),
+        ],
+        constraints=[],
+        ideal_outcome="add sums",
+        check="tests",
+    )
+    bad_diff = """diff --git a/mod.py b/mod.py\n@@\n-def add(x, y):\n-    return x - y\n+def add(x, y)::\n+    return x + y\n"""
+
+    monkeypatch.setattr(gates, "run_static_checks", lambda repo: (False, "syntax error"))
+    monkeypatch.setattr(gates, "run_targeted_tests", lambda cmd, repo: (True, "tests pass"))
+
+    with pytest.raises(validate.ValidationError):
+        validate.require_unified_diff(bad_diff)
+
+    # Provide a valid diff but fail gates.
+    diff = """diff --git a/mod.py b/mod.py\n@@\n-def add(x, y):\n-    return x - y\n+def add(x, y):\n+    return x + y\n"""
+    monkeypatch.setattr(gates, "run_static_checks", lambda repo: (False, "syntax error"))
+
+    result = tnr.txn_patch(ctx, step, [types.DiffProposal(step_id=step.id, unified_diff=diff, rationale="fix")])
+    assert not result.committed
+    assert "return x - y" in (git_repo / "mod.py").read_text()
+
+

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,44 @@
+import dataclasses
+
+import pytest
+
+from coding_in_parallel import types
+
+
+def test_ast_span_dataclass_fields():
+    span = types.AstSpan(
+        file="example.py",
+        start_line=1,
+        end_line=5,
+        node_type="FunctionDef",
+        symbol="example",
+        score=0.9,
+    )
+    assert dataclasses.is_dataclass(types.AstSpan)
+    assert span.file == "example.py"
+    assert span.start_line == 1
+    assert span.end_line == 5
+    assert span.node_type == "FunctionDef"
+    assert span.symbol == "example"
+    assert span.score == pytest.approx(0.9)
+
+
+def test_plan_step_check_enum():
+    step = types.PlanStep(
+        id="step-1",
+        intent="Fix the bug",
+        target_spans=[
+            types.AstSpan(
+                file="example.py",
+                start_line=10,
+                end_line=12,
+                node_type="FunctionDef",
+            )
+        ],
+        constraints=["keep API"],
+        ideal_outcome="Tests pass",
+        check="tests",
+    )
+    assert step.check in {"compile", "lint", "tests", "custom"}
+
+

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,42 @@
+import pytest
+
+from coding_in_parallel import types, validate
+
+
+VALID_DIFF = """diff --git a/mod.py b/mod.py
+@@
+-def add(x, y):
+-    return x - y
++def add(x, y):
++    return x + y
+"""
+
+
+def test_validate_diff_succeeds_for_well_formed_diff():
+    validate.require_unified_diff(VALID_DIFF)
+
+
+def test_within_limits_counts_changed_lines():
+    span = types.AstSpan(file="mod.py", start_line=1, end_line=4, node_type="FunctionDef")
+    validate.ensure_within_limits(
+        VALID_DIFF,
+        allowed_files={"mod.py"},
+        max_loc=6,
+        max_files=1,
+        target_spans=[span],
+    )
+
+
+def test_within_limits_raises_for_too_many_files():
+    diff = VALID_DIFF.replace("b/mod.py", "b/other.py")
+    span = types.AstSpan(file="mod.py", start_line=1, end_line=4, node_type="FunctionDef")
+    with pytest.raises(validate.ValidationError):
+        validate.ensure_within_limits(
+            diff,
+            allowed_files={"mod.py"},
+            max_loc=6,
+            max_files=1,
+            target_spans=[span],
+        )
+
+

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -1,0 +1,23 @@
+import subprocess
+from pathlib import Path
+
+from coding_in_parallel import vcs
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=path, check=True)
+    (path / "file.txt").write_text("hello\n")
+    subprocess.run(["git", "add", "file.txt"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=path, check=True, capture_output=True)
+
+
+def test_apply_and_final_patch(tmp_path: Path):
+    _init_repo(tmp_path)
+    diff = """diff --git a/file.txt b/file.txt\n@@\n-hello\n+hello world\n"""
+    vcs.apply_diff(diff, str(tmp_path))
+    patch = vcs.final_patch(str(tmp_path))
+    assert "hello world" in patch
+    vcs.revert(str(tmp_path), vcs.checkpoint(str(tmp_path)))
+


### PR DESCRIPTION
## Summary
- create the coding_in_parallel package implementing AST indexing, planning/proposing, transactional execution, CLI, prompts, and config
- add comprehensive pytest suite covering types, planner, proposer, gates, investigator, vcs, tnr, and controller flows
- document setup in README and provide pyproject/Makefile scaffolding for editable installs

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cc6b9247808326ace1273630dcd9eb