### PR TITLE
Align CLI naming and harden transactional pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 install:
-python -m venv .venv && . .venv/bin/activate && pip install -e .
+	python -m venv .venv && . .venv/bin/activate && pip install -e .
 
 run:
-swe-fix-agent --repo $$REPO --task $$TASK --out /tmp/patch.diff --test-cmd "pytest -q"
+	coding-in-parallel --repo $$REPO --task $$TASK --out /tmp/patch.diff --test-cmd "pytest -q"
 
 logs:
-@ls -ltr .agent_runs | tail -n 5
+	@ls -ltr .agent_runs | tail -n 5
 
 lint:
-python -m py_compile $(shell git ls-files '*.py')
+	python -m py_compile $(shell git ls-files '*.py')

--- a/README.md
+++ b/README.md
@@ -27,6 +27,28 @@ Run the test suite with `pytest`:
 pytest
 ```
 
+### Running the agent
+
 The CLI entrypoint `coding-in-parallel` can be invoked manually once configured with a
-SWE-bench instance JSON and repository checkout.
+SWE-bench instance JSON and repository checkout. The configuration file defaults to
+`./config.yaml`, but you can supply an alternative path with `--config`:
+
+```bash
+coding-in-parallel \
+  --repo /path/to/repo \
+  --task /path/to/instance.json \
+  --out /tmp/patch.diff \
+  --test-cmd "pytest -q" \
+  --config config.yaml
+```
+
+Model providers require credentials. For the default OpenAI configuration, export:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+export OPENAI_API_BASE="https://api.openai.com/v1"  # optional override
+```
+
+Then provide a client implementation that consumes these variables via
+`coding_in_parallel.llm.set_client(...)` before running the agent.
 

--- a/prompts/ast_recall.txt
+++ b/prompts/ast_recall.txt
@@ -1,2 +1,10 @@
-You are the AST investigator. Given failing tests {failing_tests} for task {instance_id},
-return a JSON array of candidate spans with keys id, hypothesis, spans, and evidence.
+You are the AST investigator for task {instance_id} with failing tests {failing_tests}.
+Return JSON ONLY in the shape:
+{{"candidates":[
+  {{"id":"<short-id>",
+    "hypothesis":"<=20 words",
+    "spans":[{{"file":"<path>","start_line":N,"end_line":N,"node_type":"<AST node>","symbol":null,"score":1.0}}],
+    "evidence":{{"trace":"...","tests":"..."}}
+  }}
+]}}
+Do not include prose before or after the JSON. Ensure numeric fields are integers.

--- a/prompts/propose_diff.txt
+++ b/prompts/propose_diff.txt
@@ -1,5 +1,16 @@
-You must return a JSON list (length <= {k}) of objects with step_id, unified_diff, rationale.
-Step intent: {step}
-Target files: {spans}
-Context:
+You are editing code to satisfy the plan intent below.
+
+Output JSON ONLY: a list (length <= {k}) of objects with keys
+"step_id" (string), "unified_diff" (string), and "rationale" (<=40 words).
+
+Requirements for each "unified_diff":
+* MUST start with "diff --git" and contain at least one "@@" hunk.
+* MUST edit only these files/line ranges: 
+{span_summary}
+* MUST keep total changed lines <= {max_loc}.
+* MUST NOT include prose or code outside the provided context slices.
+
+Plan intent: {step}
+
+Context snippets:
 {context}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,9 @@ description = "Transactional SWE-bench fixer agent"
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [{name = "OpenAI", email = "support@openai.com"}]
-dependencies = []
+dependencies = [
+    "pyyaml>=6.0,<7",
+]
 
 [project.optional-dependencies]
 test = ["pytest>=7"]

--- a/src/coding_in_parallel/__init__.py
+++ b/src/coding_in_parallel/__init__.py
@@ -1,9 +1,25 @@
 """coding-in-parallel package."""
 
-from . import ast_index, controller, gates, investigator, llm, logging, main, planner, proposer, tnr, types, validate, vcs  # noqa: F401
+from . import (
+    ast_index,
+    config,
+    controller,
+    gates,
+    investigator,
+    llm,
+    logging,
+    main,
+    planner,
+    proposer,
+    tnr,
+    types,
+    validate,
+    vcs,
+)  # noqa: F401
 
 __all__ = [
     "ast_index",
+    "config",
     "controller",
     "gates",
     "investigator",

--- a/src/coding_in_parallel/config.py
+++ b/src/coding_in_parallel/config.py
@@ -1,0 +1,114 @@
+"""Configuration loading helpers for coding-in-parallel."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+def _filter_kwargs(data: Dict[str, Any], *, allowed: set[str]) -> Dict[str, Any]:
+    return {key: value for key, value in data.items() if key in allowed}
+
+
+@dataclass(frozen=True)
+class ModelConfig:
+    provider: str | None = None
+    name: str | None = None
+
+
+@dataclass(frozen=True)
+class SearchConfig:
+    max_steps: int = 4
+    diffs_per_step: int = 3
+    finalists: int = 2
+    retries_per_step: int = 1
+
+
+@dataclass(frozen=True)
+class LimitsConfig:
+    max_loc_changes: int = 12
+    max_files_per_diff: int = 2
+    slice_padding_lines: int = 80
+
+
+@dataclass(frozen=True)
+class TnrConfig:
+    actions_per_txn: int = 3
+    require_mu_nonworsening: bool = True
+
+
+@dataclass(frozen=True)
+class GateConfig:
+    static: bool = True
+    targeted_tests: bool = True
+    smoke: bool = False
+
+
+@dataclass(frozen=True)
+class LoggingConfig:
+    dir: str = ".agent_runs"
+
+
+@dataclass(frozen=True)
+class Config:
+    """Aggregated configuration for the agent."""
+
+    model: ModelConfig = field(default_factory=ModelConfig)
+    search: SearchConfig = field(default_factory=SearchConfig)
+    limits: LimitsConfig = field(default_factory=LimitsConfig)
+    tnr: TnrConfig = field(default_factory=TnrConfig)
+    gates: GateConfig = field(default_factory=GateConfig)
+    logging: LoggingConfig = field(default_factory=LoggingConfig)
+
+    @classmethod
+    def default(cls) -> "Config":
+        return cls()
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Config":
+        search = SearchConfig(**_filter_kwargs(data.get("search", {}), allowed=set(SearchConfig.__annotations__.keys())))
+        limits = LimitsConfig(**_filter_kwargs(data.get("limits", {}), allowed=set(LimitsConfig.__annotations__.keys())))
+        tnr_cfg = TnrConfig(**_filter_kwargs(data.get("tnr", {}), allowed=set(TnrConfig.__annotations__.keys())))
+        gates = GateConfig(**_filter_kwargs(data.get("gates", {}), allowed=set(GateConfig.__annotations__.keys())))
+        logging_cfg = LoggingConfig(
+            **_filter_kwargs(data.get("logging", {}), allowed=set(LoggingConfig.__annotations__.keys()))
+        )
+        model_cfg = ModelConfig(**_filter_kwargs(data.get("model", {}), allowed=set(ModelConfig.__annotations__.keys())))
+        return cls(
+            model=model_cfg,
+            search=search,
+            limits=limits,
+            tnr=tnr_cfg,
+            gates=gates,
+            logging=logging_cfg,
+        )
+
+    @classmethod
+    def load(cls, path: str | Path | None = None) -> "Config":
+        """Load configuration from *path* if it exists, otherwise defaults."""
+
+        if path is None:
+            path = Path("config.yaml")
+        else:
+            path = Path(path)
+        if not path.exists():
+            return cls.default()
+        raw = yaml.safe_load(path.read_text()) or {}
+        if not isinstance(raw, dict):
+            raise ValueError("Config file must contain a mapping at the top level.")
+        return cls.from_dict(raw)
+
+
+__all__ = [
+    "Config",
+    "GateConfig",
+    "LimitsConfig",
+    "LoggingConfig",
+    "ModelConfig",
+    "SearchConfig",
+    "TnrConfig",
+]
+

--- a/src/coding_in_parallel/controller.py
+++ b/src/coding_in_parallel/controller.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
-from . import investigator, planner, proposer, tnr, types, vcs
+from . import config as config_module, investigator, planner, proposer, tnr, types, vcs
 
 
 @dataclass
@@ -17,31 +17,60 @@ class ControllerResult:
     plan: List[types.PlanStep] = field(default_factory=list)
 
 
-def _load_context(repo_path: str, step: types.PlanStep) -> dict[str, str]:
+def _load_context(repo_path: str, step: types.PlanStep, padding: int) -> Dict[str, str]:
     root = Path(repo_path)
-    context: dict[str, str] = {}
+    grouped: Dict[str, List[str]] = {}
     for span in step.target_spans:
         file_path = root / span.file
-        if file_path.exists():
-            context[span.file] = file_path.read_text()
-    return context
+        if not file_path.exists():
+            continue
+        lines = file_path.read_text().splitlines()
+        start_index = max(span.start_line - 1 - padding, 0)
+        end_index = min(span.end_line + padding, len(lines))
+        snippet = lines[start_index:end_index]
+        numbered = "\n".join(
+            f"{start_index + idx + 1:>4}: {line}" for idx, line in enumerate(snippet)
+        )
+        grouped.setdefault(span.file, []).append(
+            f"LINES {start_index + 1}-{end_index}:\n{numbered}"
+        )
+    return {file: "\n\n".join(snippets) for file, snippets in grouped.items()}
 
 
-def run_controller(ctx: types.TaskContext, *, max_steps: int = 4, diffs_per_step: int = 3) -> ControllerResult:
+def run_controller(
+    ctx: types.TaskContext,
+    *,
+    config: config_module.Config | None = None,
+) -> ControllerResult:
     """Run the investigation → planning → execution loop."""
 
+    cfg = config or config_module.Config.default()
     candidates = investigator.recall_candidates(ctx)
     candidates = investigator.probe(ctx, candidates)
     understanding = planner.synthesize(candidates)
-    plan = planner.plan(understanding)[:max_steps]
+    plan = planner.plan(understanding)[: cfg.search.max_steps]
 
     transactions: List[tnr.TransactionResult] = []
     for step in plan:
-        ctx_files = _load_context(ctx.repo_path, step)
-        proposals = proposer.propose(step, ctx_files, diffs_per_step)
-        result = tnr.txn_patch(ctx, step, proposals, max_actions=diffs_per_step)
-        transactions.append(result)
-        if result.committed:
+        ctx_files = _load_context(ctx.repo_path, step, cfg.limits.slice_padding_lines)
+        step_committed = False
+        for _attempt in range(max(1, cfg.search.retries_per_step)):
+            proposals = proposer.propose(step, ctx_files, config=cfg)
+            finalists = max(1, cfg.search.finalists)
+            shortlisted = proposals[:finalists]
+            if not shortlisted:
+                continue
+            result = tnr.txn_patch(
+                ctx,
+                step,
+                shortlisted,
+                config=cfg,
+            )
+            transactions.append(result)
+            if result.committed:
+                step_committed = True
+                break
+        if step_committed:
             break
 
     patch = vcs.final_patch(ctx.repo_path)

--- a/src/coding_in_parallel/main.py
+++ b/src/coding_in_parallel/main.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 from typing import Iterable
 
-from . import controller, types
+from . import config as config_module, controller, types
 
 
 def _parse_args(args: Iterable[str] | None = None) -> argparse.Namespace:
@@ -16,6 +16,11 @@ def _parse_args(args: Iterable[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--task", required=True, help="Path to SWE-bench task JSON")
     parser.add_argument("--out", required=True, help="Where to write the final patch")
     parser.add_argument("--test-cmd", required=True, help="Command used for targeted tests")
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to YAML configuration file (defaults to ./config.yaml if omitted)",
+    )
     return parser.parse_args(list(args) if args is not None else None)
 
 
@@ -30,7 +35,8 @@ def main(argv: Iterable[str] | None = None) -> None:
         instance_id=task_data.get("instance_id", "unknown"),
         metadata=task_data.get("metadata", {}),
     )
-    result = controller.run_controller(ctx)
+    cfg = config_module.Config.load(ns.config)
+    result = controller.run_controller(ctx, config=cfg)
     Path(ns.out).write_text(result.final_patch)
 
 

--- a/src/coding_in_parallel/proposer.py
+++ b/src/coding_in_parallel/proposer.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Dict, List
 
-from . import llm, types
+from . import config as config_module, llm, types
 
 _PROMPT_DIR = Path(__file__).resolve().parents[2] / "prompts"
 
@@ -18,7 +18,22 @@ def _load_prompt(name: str) -> str:
     return path.read_text().strip()
 
 
-def propose(step: types.PlanStep, ctx_files: Dict[str, str], k: int) -> List[types.DiffProposal]:
+def _format_span_summary(step: types.PlanStep) -> str:
+    parts = []
+    for span in step.target_spans:
+        symbol = f" {span.symbol}" if span.symbol else ""
+        parts.append(
+            f"- {span.file}:{span.start_line}-{span.end_line} ({span.node_type}{symbol})"
+        )
+    return "\n".join(parts) if parts else "- (no target spans provided)"
+
+
+def propose(
+    step: types.PlanStep,
+    ctx_files: Dict[str, str],
+    *,
+    config: config_module.Config,
+) -> List[types.DiffProposal]:
     """Produce up to *k* unified diff proposals for *step*."""
 
     prompt = _load_prompt("propose_diff.txt")
@@ -27,18 +42,30 @@ def propose(step: types.PlanStep, ctx_files: Dict[str, str], k: int) -> List[typ
         context_lines.append(f"FILE: {file}\n{content}")
     payload = {
         "step": step.intent,
-        "spans": [span.file for span in step.target_spans],
-        "context": "\n".join(context_lines),
-        "k": k,
+        "span_summary": _format_span_summary(step),
+        "context": "\n\n".join(context_lines) or "(no context available)",
+        "k": config.search.diffs_per_step,
+        "max_loc": config.limits.max_loc_changes,
     }
-    response = llm.complete(prompt.format(**payload))
-    items = json.loads(response or "[]")
+    formatted_prompt = prompt.format(**payload)
+    response = llm.complete(formatted_prompt)
+    try:
+        items = json.loads(response or "[]")
+    except json.JSONDecodeError as exc:  # pragma: no cover - guard rails
+        raise ValueError(f"Proposer returned non-JSON output: {exc}") from exc
+    if not isinstance(items, list):
+        raise ValueError("Proposer output must be a JSON list of proposals.")
     proposals: List[types.DiffProposal] = []
-    for raw in items[:k]:
+    for raw in items[: config.search.diffs_per_step]:
+        if not isinstance(raw, dict):
+            raise ValueError("Each proposal must be a JSON object with diff fields.")
+        diff = raw.get("unified_diff")
+        if not isinstance(diff, str):
+            raise ValueError("Proposal missing 'unified_diff' string field.")
         proposals.append(
             types.DiffProposal(
-                step_id=raw.get("step_id", step.id),
-                unified_diff=raw["unified_diff"],
+                step_id=str(raw.get("step_id", step.id)),
+                unified_diff=diff,
                 rationale=raw.get("rationale"),
             )
         )

--- a/tests/test_investigator.py
+++ b/tests/test_investigator.py
@@ -29,26 +29,29 @@ def _make_ctx(repo_path: Path) -> types.TaskContext:
 def test_recall_candidates_parses_llm_output(monkeypatch: pytest.MonkeyPatch, repo_with_bug: Path):
     ctx = _make_ctx(repo_with_bug)
     response = json.dumps(
-        [
-            {
-                "id": "cand-1",
-                "hypothesis": "The function subtracts instead of adds.",
-                "spans": [
-                    {
-                        "file": "mod.py",
-                        "start_line": 1,
-                        "end_line": 2,
-                        "node_type": "FunctionDef",
-                        "symbol": "add",
-                    }
-                ],
-                "evidence": {"score": 0.8},
-            }
-        ]
+        {
+            "candidates": [
+                {
+                    "id": "cand-1",
+                    "hypothesis": "The function subtracts instead of adds.",
+                    "spans": [
+                        {
+                            "file": "mod.py",
+                            "start_line": 1,
+                            "end_line": 2,
+                            "node_type": "FunctionDef",
+                            "symbol": "add",
+                            "score": 0.8,
+                        }
+                    ],
+                    "evidence": {"score": 0.8},
+                }
+            ]
+        }
     )
 
     def fake_complete(prompt: str, **_: object) -> str:
-        assert "ast" in prompt.lower()
+        assert "Return JSON ONLY" in prompt
         return response
 
     monkeypatch.setattr(llm, "complete", fake_complete)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -32,7 +32,7 @@ def test_main_cli_writes_patch_file(monkeypatch: pytest.MonkeyPatch, tmp_path: P
     instance_path.write_text(json.dumps(instance))
     output_path = tmp_path / "patch.diff"
 
-    def fake_run_controller(ctx: types.TaskContext):
+    def fake_run_controller(ctx: types.TaskContext, *, config):
         return controller.ControllerResult(
             final_patch="diff --git a/mod.py b/mod.py\n",
             transactions=[],

--- a/tests/test_proposer.py
+++ b/tests/test_proposer.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from coding_in_parallel import proposer, llm, types
+from coding_in_parallel import config as config_module, llm, proposer, types
 
 
 def test_propose_returns_diff_list(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
@@ -19,7 +19,7 @@ def test_propose_returns_diff_list(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     )
 
     def fake_complete(prompt: str, **_: object) -> str:
-        assert "diff" in prompt.lower()
+        assert "Output JSON ONLY" in prompt
         return response
 
     monkeypatch.setattr(llm, "complete", fake_complete)
@@ -35,6 +35,11 @@ def test_propose_returns_diff_list(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
         ideal_outcome="add returns sum",
         check="tests",
     )
-    proposals = proposer.propose(step, {"mod.py": "def add(x, y):\n    return x - y\n"}, 1)
+    cfg = config_module.Config.default()
+    proposals = proposer.propose(
+        step,
+        {"mod.py": "LINES 1-2:\n   1: def add(x, y):\n   2:     return x - y"},
+        config=cfg,
+    )
     assert proposals and proposals[0].rationale.startswith("Swap")
 

--- a/tests/test_tnr.py
+++ b/tests/test_tnr.py
@@ -1,9 +1,10 @@
 import subprocess
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
-from coding_in_parallel import gates, tnr, types, validate, vcs
+from coding_in_parallel import config as config_module, gates, tnr, types, validate, vcs
 
 
 def _init_git_repo(path: Path) -> None:
@@ -34,6 +35,7 @@ def _make_context(repo_path: Path) -> types.TaskContext:
 
 def test_txn_patch_commits_when_checks_pass(monkeypatch: pytest.MonkeyPatch, git_repo: Path):
     ctx = _make_context(git_repo)
+    cfg = config_module.Config.default()
     step = types.PlanStep(
         id="step-1",
         intent="Fix add",
@@ -44,19 +46,25 @@ def test_txn_patch_commits_when_checks_pass(monkeypatch: pytest.MonkeyPatch, git
         ideal_outcome="add sums",
         check="tests",
     )
-    diff = """diff --git a/mod.py b/mod.py\n@@\n-def add(x, y):\n-    return x - y\n+def add(x, y):\n+    return x + y\n"""
+    diff = """diff --git a/mod.py b/mod.py\n@@ -1,2 +1,2 @@\n-def add(x, y):\n-    return x - y\n+def add(x, y):\n+    return x + y\n"""
 
     monkeypatch.setattr(gates, "run_static_checks", lambda repo: (True, "ok"))
     monkeypatch.setattr(gates, "run_targeted_tests", lambda cmd, repo: (True, "tests pass"))
 
-    result = tnr.txn_patch(ctx, step, [types.DiffProposal(step_id=step.id, unified_diff=diff, rationale="fix")])
+    result = tnr.txn_patch(
+        ctx,
+        step,
+        [types.DiffProposal(step_id=step.id, unified_diff=diff, rationale="fix")],
+        config=cfg,
+    )
     assert result.committed
-    assert result.mu_post <= result.mu_pre + 2
+    assert result.mu_post == 0
     assert "return x + y" in (git_repo / "mod.py").read_text()
 
 
 def test_txn_patch_rolls_back_on_failure(monkeypatch: pytest.MonkeyPatch, git_repo: Path):
     ctx = _make_context(git_repo)
+    cfg = config_module.Config.default()
     step = types.PlanStep(
         id="step-1",
         intent="Fix add",
@@ -67,7 +75,7 @@ def test_txn_patch_rolls_back_on_failure(monkeypatch: pytest.MonkeyPatch, git_re
         ideal_outcome="add sums",
         check="tests",
     )
-    bad_diff = """diff --git a/mod.py b/mod.py\n@@\n-def add(x, y):\n-    return x - y\n+def add(x, y)::\n+    return x + y\n"""
+    bad_diff = """diff --git a/mod.py b/mod.py\n@@ -1,2 +1,2 @@\n-def add(x, y):\n-    return x - y\n+def add(x, y)::\n+    return x + y\n"""
 
     monkeypatch.setattr(gates, "run_static_checks", lambda repo: (False, "syntax error"))
     monkeypatch.setattr(gates, "run_targeted_tests", lambda cmd, repo: (True, "tests pass"))
@@ -76,11 +84,45 @@ def test_txn_patch_rolls_back_on_failure(monkeypatch: pytest.MonkeyPatch, git_re
         validate.require_unified_diff(bad_diff)
 
     # Provide a valid diff but fail gates.
-    diff = """diff --git a/mod.py b/mod.py\n@@\n-def add(x, y):\n-    return x - y\n+def add(x, y):\n+    return x + y\n"""
+    diff = """diff --git a/mod.py b/mod.py\n@@ -1,2 +1,2 @@\n-def add(x, y):\n-    return x - y\n+def add(x, y):\n+    return x + y\n"""
     monkeypatch.setattr(gates, "run_static_checks", lambda repo: (False, "syntax error"))
 
-    result = tnr.txn_patch(ctx, step, [types.DiffProposal(step_id=step.id, unified_diff=diff, rationale="fix")])
+    result = tnr.txn_patch(
+        ctx,
+        step,
+        [types.DiffProposal(step_id=step.id, unified_diff=diff, rationale="fix")],
+        config=cfg,
+    )
     assert not result.committed
     assert "return x - y" in (git_repo / "mod.py").read_text()
+
+
+def test_txn_patch_rolls_back_when_mu_worsens(monkeypatch: pytest.MonkeyPatch, git_repo: Path):
+    ctx = _make_context(git_repo)
+    cfg = config_module.Config.default()
+    cfg = replace(cfg, gates=replace(cfg.gates, targeted_tests=False))
+    step = types.PlanStep(
+        id="step-1",
+        intent="Add dead code",
+        target_spans=[
+            types.AstSpan(file="mod.py", start_line=1, end_line=2, node_type="FunctionDef"),
+        ],
+        constraints=[],
+        ideal_outcome="", 
+        check="",
+    )
+    diff = """diff --git a/mod.py b/mod.py\n@@ -1,2 +1,5 @@\n def add(x, y):\n-    return x - y\n+    return x - y\n+\n+def helper():\n+    return 41\n"""
+
+    monkeypatch.setattr(gates, "run_static_checks", lambda repo: (True, "ok"))
+
+    result = tnr.txn_patch(
+        ctx,
+        step,
+        [types.DiffProposal(step_id=step.id, unified_diff=diff, rationale="noop")],
+        config=cfg,
+    )
+    assert not result.committed
+    assert any("mu worsened" in log for log in result.logs)
+    assert "helper" not in (git_repo / "mod.py").read_text()
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -4,7 +4,7 @@ from coding_in_parallel import types, validate
 
 
 VALID_DIFF = """diff --git a/mod.py b/mod.py
-@@
+@@ -1,2 +1,2 @@
 -def add(x, y):
 -    return x - y
 +def add(x, y):
@@ -37,6 +37,20 @@ def test_within_limits_raises_for_too_many_files():
             max_loc=6,
             max_files=1,
             target_spans=[span],
+        )
+
+
+def test_within_limits_rejects_lines_outside_span():
+    diff = """diff --git a/mod.py b/mod.py\n@@ -50,0 +50,2 @@\n+print('out of range')\n"""
+    span = types.AstSpan(file="mod.py", start_line=1, end_line=10, node_type="Module")
+    with pytest.raises(validate.ValidationError):
+        validate.ensure_within_limits(
+            diff,
+            allowed_files={"mod.py"},
+            max_loc=5,
+            max_files=1,
+            target_spans=[span],
+            padding_lines=0,
         )
 
 


### PR DESCRIPTION
## Summary
- align documentation and tooling on the `coding-in-parallel` CLI while adding YAML-driven configuration loading
- strengthen prompts and JSON parsing for investigators/proposers with padded context slices and diff budgets
- enforce transactional limits and rollback behaviour via config-aware validators and expanded regression tests

## Testing
- pytest
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68cc82a595ac8326a7c7d9397698eb9b